### PR TITLE
update to Guzzle 6

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,6 +1,6 @@
 {
   "generalSettings": {
-    "shouldScanRepo": true
+    "shouldScanRepo": false
   },
   "checkRunSettings": {
     "vulnerableCheckRunConclusionLevel": "failure"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 SIL International
+Copyright (c) 2020 SIL International
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -5,14 +5,13 @@
   "keywords": ["trello"],
   "license": "MIT",
   "require": {
-    "php": ">=5.4.0",
-    "guzzlehttp/guzzle": "^5.3.1",
-    "guzzlehttp/guzzle-services": "*",
-    "guzzlehttp/retry-subscriber": "*",
-    "guzzlehttp/log-subscriber": "*"
+    "php": ">=7.2.0",
+    "guzzlehttp/guzzle-services": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.0"
+    "ext-json": "*",
+    "phpunit/phpunit": "~4.0",
+    "roave/security-advisories": "dev-master"
   },
   "authors": [
     {

--- a/src/BaseClient.php
+++ b/src/BaseClient.php
@@ -4,7 +4,6 @@ namespace Trello;
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Command\Guzzle\GuzzleClient;
 use GuzzleHttp\Command\Guzzle\Description;
-use GuzzleHttp\Subscriber\Retry\RetrySubscriber;
 
 /**
  * Partial Trello API client implemented with Guzzle.
@@ -17,26 +16,17 @@ class BaseClient extends GuzzleClient
      */
     public function __construct(array $config = [])
     {
-        // Apply some defaults.
-        $config += [
-            'max_retries'      => 3,
-        ];
-
         // Create the client.
         parent::__construct(
             $this->getHttpClientFromConfig($config),
             $this->getDescriptionFromConfig($config),
+            null,
+            null,
+            null,
             $config
         );
 
-        // Ensure that the credentials are set.
-        $this->applyCredentials($config);
-
-        // Ensure that ApiVersion is set.
-        $this->setConfig(
-            'defaults/ApiVersion',
-            $this->getDescription()->getApiVersion()
-        );
+        $this->setDefaults($config);
     }
 
     private function getHttpClientFromConfig(array $config)
@@ -51,15 +41,6 @@ class BaseClient extends GuzzleClient
             ? $config['http_client_options']
             : [];
         $client = new HttpClient($clientOptions);
-
-        // Attach request retry logic.
-        $client->getEmitter()->attach(new RetrySubscriber([
-            'max' => $config['max_retries'],
-            'filter' => RetrySubscriber::createChainFilter([
-                RetrySubscriber::createStatusFilter(),
-                RetrySubscriber::createCurlFilter(),
-            ]),
-        ]));
 
         return $client;
     }
@@ -77,14 +58,14 @@ class BaseClient extends GuzzleClient
             : null;
 
         // Override description from local config if set
-        if(isset($config['description_override'])){
+        if (isset($config['description_override'])) {
             $data = array_merge($data, $config['description_override']);
         }
 
         return new Description($data);
     }
 
-    private function applyCredentials(array $config)
+    private function setDefaults(array $config)
     {
         // Ensure that the credentials have been provided.
         if (!isset($config['key'])) {
@@ -97,15 +78,17 @@ class BaseClient extends GuzzleClient
                 'You must provide an Api Token.'
             );
         }
+
+        $defaults = [];
+
         // Set credentials in default variables so that we don't
         // have to pass them to every method individually
-        $this->setConfig(
-            'defaults/key',
-            $config['key']
-        );
-        $this->setConfig(
-            'defaults/token',
-            $config['token']
-        );
+        $defaults['key'] = $config['key'];
+        $defaults['token'] = $config['token'];
+
+        // Ensure that ApiVersion is set.
+        $defaults['ApiVersion'] = $this->getDescription()->getApiVersion();
+
+        $this->setConfig('defaults', $defaults);
     }
 }


### PR DESCRIPTION
required changes:
- `guzzlehttp/retry-subscriber` was removed, so no automatic API retries
- `setConfig` changed how arguments are passed (slash-separated to nested array)
- test mocks are created differently
- Guzzle services client now throws `CommandClientException` instead of `RequestException` when an error response code is received